### PR TITLE
Fix double-registration of mapper modules

### DIFF
--- a/app/mappings/esdn_mods.rb
+++ b/app/mappings/esdn_mods.rb
@@ -1,4 +1,7 @@
-Krikri::Mapper.define(:esdn_mods) do
-  sourceResource :class => DPLA::MAP::SourceResource do
+
+if !Krikri::Mapper::Registry.registered?(:esdn_mods)
+  Krikri::Mapper.define(:esdn_mods) do
+    sourceResource :class => DPLA::MAP::SourceResource do
+    end
   end
 end


### PR DESCRIPTION
The Resque :preload task wants to eagerly load our application's
classes:
https://github.com/resque/resque/blob/1-x-stable/lib/resque/tasks.rb#L62

For reasons that aren't yet clear, this was causing the
Krikri::Mapper.define call in esdn_mods.rb to happen twice.  This, of
course, was throwing an exception.  The application was loading
correctly in the Rails console, but not in the resque:work rake task.

This change introduces a simple conditional to call #define only if the
mapping is unregistered.