### PR TITLE
Improve Redis / Resque configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,3 +40,4 @@ gem "jettywrapper", "~> 2.0", group: :development
 gem "devise", "~> 3.4.1"
 gem 'pg', '<2.0.0'
 gem 'unicorn', '~> 4.8.3'
+gem 'rails_config'

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+settings.local.yml

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,5 @@
+
+$redis = Redis.new(Settings.redis.to_hash)
+$redis_ns = Redis::Namespace.new(Settings.redis.namespace, redis: $redis)
+
+$redis.flushdb if Rails.env == 'test'

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,0 @@
-
-$redis = Redis.new(Settings.redis.to_hash)
-$redis_ns = Redis::Namespace.new(Settings.redis.namespace, redis: $redis)
-
-$redis.flushdb if Rails.env == 'test'

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,2 +1,5 @@
 
-Resque.redis = $redis
+Resque.redis = "#{Settings.redis.host}:#{Settings.redis.port}"
+Resque.redis.namespace = Settings.redis.namespace
+
+Resque.redis.flushdb if Rails.env == 'test'

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,2 @@
+
+Resque.redis = $redis

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,4 +6,3 @@
 redis:
     host: localhost
     port: 6379
-    db: 0

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,9 @@
+---
+
+# Defaults.
+# Override per https://github.com/railsconfig/rails_config#common-config-file
+
+redis:
+    host: localhost
+    port: 6379
+    db: 0

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,5 @@
+---
+
+redis:
+    db: 0
+    namespace: heidrun_dev

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,5 @@
+---
+
+redis:
+    db: 1
+    namespace: heidrun_prod

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,5 @@
+---
+
+redis:
+    db: 0
+    namespace: heidrun_test


### PR DESCRIPTION
Use rails_config, with overridable settings files, to make it easier to specify environment-specific connection settings for the Redis server, and the namespace for the Resque queues.

This is going to be followed by a related PR to `automation`, in which a `settings.local.yml` file is created to override the Redis hostname, without creating Ruby code in an initializer file, as it does now.

I've tested this in a VM, and it appears that Resque has a good Redis connection, because I can check the queue's count without error.
