### PR TITLE
Isolate mapping test from individual/real mappings

### DIFF
--- a/spec/mappings/mappings_spec.rb
+++ b/spec/mappings/mappings_spec.rb
@@ -8,9 +8,15 @@ describe 'mappings' do
       expect(Krikri::Mapper::Registry.keys).not_to be_empty
     end
 
-    it 'creates a DPLA::MAP record', krikri_integration: true do
-      expect(Krikri::Mapper.map(Krikri::Mapper::Registry.keys.first, record))
-        .to contain_exactly(an_instance_of(DPLA::MAP::Aggregation))
+    context 'with mapping' do
+      before do
+        Krikri::Mapper.define(:rspec_test_mapping) {}
+      end
+
+      it 'creates a DPLA::MAP record', krikri_integration: true do
+        expect(Krikri::Mapper.map(:rspec_test_mapping, record))
+          .to contain_exactly(an_instance_of(DPLA::MAP::Aggregation))
+      end
     end
   end
 end


### PR DESCRIPTION
This test was susceptible to failure because the selected parser or parser arguments for the mapping specified by Krikri::Mapper::Registry.keys.first` did not exist in the dummy record.

This isolates it from that external detail.