### PR TITLE
Avoid overlapping factory names w/ KriKri

### DIFF
--- a/spec/factories/heidrun_original_record.rb
+++ b/spec/factories/heidrun_original_record.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 FactoryGirl.define do
 
   factory :heidrun_original_record, class: Krikri::OriginalRecord do
@@ -5,7 +6,7 @@ FactoryGirl.define do
     initialize_with { new('abc') }
   end
 
-  factory :oai_dc_record, parent: :heidrun_original_record do
+  factory :heidrun_oai_dc_record, parent: :heidrun_original_record do
     content <<-EOS
 <?xml version="1.0" encoding="UTF-8"?>
 

--- a/spec/mappings/mappings_spec.rb
+++ b/spec/mappings/mappings_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'mappings' do
-  let(:record) { build(:oai_dc_record) }
+  let(:record) { build(:heidrun_oai_dc_record) }
 
   describe '#map' do
     it 'has registered mappings' do


### PR DESCRIPTION
This undoes name collision on a factory. A more general strategy should be adopted per: https://www.pivotaltracker.com/story/show/87853896

This is the cause of the :travis: failure on #18.