### PR TITLE
Allow `require`-ing of vendored mappings to traverse symlinks

### DIFF
--- a/config/initializers/metadata_mappings.rb
+++ b/config/initializers/metadata_mappings.rb
@@ -1,1 +1,6 @@
-Dir[Rails.root.join('vendor/mappings/**/*.rb')].each { |f| require f }
+# The strange looking glob allows us to traverse one level of symlinks on
+# supported platforms; see http://stackoverflow.com/questions/357754
+
+Dir[Rails.root.join('vendor', 'mappings', '**{,/*/**}', '*.rb')].each do |f|
+  require f
+end


### PR DESCRIPTION
This should make deployment potentially easier in some cases, especially when
working with a local working copy not in a VM.