### PR TITLE
Add MDL Harvester

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.1.9'
 
-gem 'krikri', '~>0.3.3'
+gem 'krikri', '~>0.4.0'
 
 gem 'sqlite3'
 gem 'sass-rails', '~> 4.0.3'

--- a/app/harvesters/mdl_harvester.rb
+++ b/app/harvesters/mdl_harvester.rb
@@ -1,0 +1,16 @@
+##
+# A harvester for MDL's API
+#
+# @see Krikri::Harvesters::ApiHarvester
+class MdlHarvester < Krikri::Harvesters::ApiHarvester
+  ##
+  # Initialize with MDL's default opts.
+  #
+  # @param opts [Hash] a hash of options as defined by {.expected_opts}
+  def initialize(opts = {})
+    opts[:uri] ||= 'http://hub-client.lib.umn.edu/api/v1/records'
+    opts[:name] ||= 'mdl'
+    super
+    @opts['params'] ||= { 'q' => 'tags_ssim:dpla' }
+  end
+end

--- a/spec/harvesters/mdl_harvester_spec.rb
+++ b/spec/harvesters/mdl_harvester_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe MdlHarvester do
+  describe '#new' do
+    it 'uses MDL options by default' do
+      expect(described_class.new)
+        .to have_attributes(uri: 'http://hub-client.lib.umn.edu/api/v1/records',
+                            name: 'mdl',
+                            opts: { 'params' => { 'q' => 'tags_ssim:dpla' } })
+    end
+
+    it 'allows override of MDL uri' do
+      uri = 'http://example.org/mdl'
+      expect(described_class.new(uri: uri))
+        .to have_attributes(uri: uri,
+                            opts: { 'params' => { 'q' => 'tags_ssim:dpla' } })
+    end
+
+    it 'allows override of MDL params' do
+      params = { 'params' => 'abc' }
+      expect(described_class.new(api: params))
+        .to have_attributes(uri: 'http://hub-client.lib.umn.edu/api/v1/records',
+                            opts: params)
+    end
+
+    it 'allows override of MDL name' do
+      harvester_name = 'moomin'
+      expect(described_class.new(name: harvester_name))
+              .to have_attributes(name: harvester_name)
+    end
+  end
+end


### PR DESCRIPTION
The MDL Harvester adds default options to the generic Krikri REST `ApiHarvester`, targeting the UMN-provided MDL API.

This depends on the `Krikri::Harvesters::ApiHarvester` introduced in Krikri 0.4.0.

This PR partially replaces dpla/krikri#122
