### PR TITLE
Add NARA harvester

### DIFF
--- a/app/harvesters/nara_harvester.rb
+++ b/app/harvesters/nara_harvester.rb
@@ -1,0 +1,128 @@
+##
+# A harvester for NARA's API
+#
+# @see https://github.com/usnationalarchives/Catalog-API/blob/master/search_and_export.md
+# @see Krikri::Harvesters::ApiHarvester
+class NaraHarvester < Krikri::Harvesters::ApiHarvester
+  DEFAULT_URI = 'https://catalog.archives.gov/api/v1'
+  DEFAULT_NAME = 'nara'
+  DEFAULT_BATCHSIZE = 10
+  DEFAULT_ID_FILENAME = '/var/tmp/nara_ids'
+  DEFAULT_PARAMS = {
+    'pretty' => 'false',
+    'resultTypes' => 'item,fileUnit',
+    'objects.object.@objectSortNum' => '1'
+  }
+
+  ##
+  # Initialize, and set default options as appropriate.
+  #
+  # @param opts [Hash] a hash of options as defined by {.expected_opts}
+  #
+  # @example
+  #    Typical instantiation, good for most cases:
+  #        NaraHarvester.new
+  #    Specifying custom parameters:
+  #        NaraHarvester.new(api: {'some_query_param' => 'abc'}, batchsize: 15)
+  #
+  # Parameters to 'opts':
+  # - uri:        See Krikri::Harvester#initialize.
+  #               Defaults to "https://catalog.archives.gov/api/v1"
+  # - name:       See Krikri::Harvester#initialize.  Defaults to "nara"
+  # - batchsize:  The number of records to fetch with each API request.
+  #               Defaults to 10.
+  # - id_fname:   The file name of the Heidrun::IDSource that drives the
+  #               harvest and governs which records to fetch.  Defaults to
+  #               /var/tmp/nara_ids.
+  # - id_fh:      A filehandle to use with Heidrun::IDSource, mostly useful for
+  #               automated testing or console usage.  Optional.
+  #
+  # For other parameters, see Krikri::Harvester#initialize.  
+  #
+  # Parameters for API requests can be specified with the :api key, but have
+  # default values and this should not usually be necessary. See
+  # https://github.com/usnationalarchives/Catalog-API/blob/master/search_and_export.md
+  #
+  # @raise [Errno::ENOENT]  If the IDSource file is missing
+  # @raise [Errno::EACCES]  If the IDSource file is unreadable
+  #
+  def initialize(opts = {})
+    opts[:uri] ||= DEFAULT_URI
+    opts[:name] ||= DEFAULT_NAME
+    batchsize = opts.delete(:batchsize) { DEFAULT_BATCHSIZE }
+    # TODO:
+    # @id_source is an enumerator over NARA identifiers (naId values).
+    # This reads from a file of valid IDs in order to work around the fact that
+    # we can not page through NARA's entire result set, due to limitations on
+    # the maximum "offset" value in their API.  When they remove this
+    # limitation from their API, remove @id_source and refactor this method,
+    # #enumerate_records, and #get_count.
+    id_fname = opts.delete(:id_source_filename) { DEFAULT_ID_FILENAME }
+    id_fh = opts.delete(:id_source_fh) { File.open(id_fname, 'rt') }
+    @id_source = Heidrun::IDSource.new(id_fh, batchsize)
+    super
+    @opts['params'] ||= DEFAULT_PARAMS
+  end
+
+  ##
+  # @see Krikri::ApiHarvester.expected_opts
+  def self.expected_opts
+    {
+      key: :api,
+      opts: {
+        params: { type: :hash, required: false},
+        id_source_filename: { type: :string, required: false}
+      }
+    }
+  end
+
+  private
+
+  ##
+  # @see Krikri::ApiHarvester#enumerate_records
+  #
+  # TODO:
+  # Per the note above in #initialize, when there is no longer an @id_source to
+  # drive the harvest, the query options above might want to be amended to pull
+  # only those records with "Unrestricted" or "Restricted - Possibly" statuses.
+  # We might need to add the following to @opts['params'] in three iterations,
+  # where item_type is one of "item", "itemAv", or "fileUnit":
+  #      "description.#{item_type}.useRestriction.status.termName" =>
+  #        'Unrestricted or "Restricted - Possibly"'
+  def enumerate_records
+    Enumerator.new do |en|
+      request_opts = opts.deep_dup
+      @id_source.batches.each do |ids|
+        request_opts['params']['naIds'] = ids.join(',')
+        begin
+          docs = get_docs(request(request_opts.dup))
+          break if docs.empty?
+          docs.each do |doc|
+            en.yield doc
+          end
+        rescue RestClient::RequestFailed => e
+          log :error, "request failed with params #{request_opts['params']}"
+          next
+        end
+      end
+    end
+  end
+
+  ##
+  # @see Krikri::ApiHarvester#get_docs
+  def get_docs(response)
+    response['opaResponse']['results']['result']
+  end
+
+  ##
+  # @see Krikri::ApiHarvester#get_identifier
+  def get_identifier(doc)
+    doc['naId']
+  end
+
+  ##
+  # @see Krikri::ApiHarvester#get_count
+  def get_count(response)
+    @id_source.count
+  end
+end

--- a/lib/heidrun/id_source.rb
+++ b/lib/heidrun/id_source.rb
@@ -1,0 +1,67 @@
+
+module Heidrun
+
+  ##
+  # A source of identifier strings to use in constructing API requests.
+  #
+  # This is a temporary trick to allow us to get around a limitation
+  # in NARA's API: we need to request a list of IDs explicitly because we can't
+  # page through their entire result set.  IDSource reads a file and gives us
+  # batches of IDs as arrays.
+  #
+  # File format:  text, with one decimal string per line, with an optional
+  # trailing comma; for example:
+  #
+  # 7441504,
+  # 7563000,
+  # 12014747,
+  # ...
+  #
+  # The optional trailing comma allows it to have been exported from Excel
+  # without any preprocessing, as the Excel-exported file we've encountered
+  # has this comma.
+  #
+  class IDSource
+
+    ##
+    # Constructor
+    #
+    # IDSource is initialized with the filehandle of a file that contains one
+    # ID string per line.
+    #
+    # The batchsize parameter will determine how many records are requested
+    # with a single request to the API.
+    #
+    # @param fh        [IO]    File-like object (File / StringIO)
+    # @param batchsize [Fixnum]
+    #
+    def initialize(fh, batchsize = 10)
+      @fh = fh
+      @batchsize = batchsize
+    end
+
+    ##
+    # Return an enumerator of arrays of identifiers.
+    # @return [Enumerator]
+    def batches
+      en = Enumerator.new do |e|
+        batch = []
+        i = 1
+        @fh.each_line do |line|
+          batch << line.chomp.delete(',')
+          if i % @batchsize == 0
+            e.yield batch
+            batch = []
+          end
+          i += 1
+        end
+        e.yield batch if batch.count > 0  # last one
+      end
+      en.lazy
+    end
+
+    def count
+      @fh.count
+    end
+  end
+end

--- a/spec/harvesters/nara_harvester_spec.rb
+++ b/spec/harvesters/nara_harvester_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+
+describe NaraHarvester do
+
+  subject { described_class.new(id_source_fh: StringIO.new) }
+  let(:default_uri) { 'https://catalog.archives.gov/api/v1' }
+  let(:default_opts) { { 'params' => described_class::DEFAULT_PARAMS } }
+  let(:doc) { {'naId' => '1', 'description' => {}, 'objects' => {}} }
+
+  describe '#new' do
+
+    context 'with default opts' do
+      it 'has the correct default properties' do
+        expect(subject).to have_attributes(uri: default_uri,
+                                           name: 'nara',
+                                           opts: default_opts)
+      end
+    end
+
+    context 'with overridden opts' do
+      let(:overridden_opts) { { 'params' => 'abc' } }
+      subject do
+        described_class.new(api: overridden_opts, id_source_fh: StringIO.new)
+      end
+
+      it 'allows override of "api" options' do
+        expect(subject)
+          .to have_attributes(uri: default_uri,
+                              name: 'nara',
+                              opts: overridden_opts)
+      end
+    end
+
+    context 'with overridden uri' do
+      let(:uri) { 'https://catalog.archives.gov/api/v2000' }
+      subject { described_class.new(uri: uri, id_source_fh: StringIO.new) }
+      it 'allows override of URI without affecting other options' do
+        expect(subject)
+          .to have_attributes(uri: uri, name: 'nara', opts: default_opts)
+      end
+    end
+
+    context 'with overridden name' do
+      subject { described_class.new(name: 'a', id_source_fh: StringIO.new) }
+      it 'allows override of name parameter' do
+        expect(subject).to have_attributes(name: 'a')
+      end
+    end
+
+    context 'with a missing IDSource file' do
+      it 'raises an Errno::ENOENT exception' do
+        expect do
+          described_class.new(id_source_filename: '/not/there')
+        end.to raise_error Errno::ENOENT
+      end
+    end
+
+    context 'with an unreadable IDSource file' do
+      before do
+        allow(File).to receive(:open).and_raise Errno::EACCES
+      end
+      it 'raises an Errno::EACCES exception' do
+        expect { described_class.new }.to raise_error Errno::EACCES
+      end
+    end
+  end  # #new
+
+  describe '#enumerate_records' do
+    let(:params_1) do
+      {
+        'params' => {
+          'pretty'=>'false', 'resultTypes'=>'item,fileUnit',
+          'objects.object.@objectSortNum'=>'1', 'naIds'=>'1,2'
+        }
+      }
+    end
+    let(:params_2) do
+      {
+        'params' => {
+          'pretty'=>'false', 'resultTypes'=>'item,fileUnit',
+          'objects.object.@objectSortNum'=>'1', 'naIds'=>'3'
+        }
+      }
+    end
+    let(:request_resp_1) { 'naids 1, 2 response' }
+    let(:request_resp_2) { 'naids 3 response' }
+    before do
+      # See Krikri::ApiHarvester#request
+      allow(subject).to receive(:request).with(params_1)
+        .and_return(request_resp_1)
+      allow(subject).to receive(:request).with(params_2)
+        .and_return(request_resp_2)
+      # See NaraHarvester#get_docs
+      allow(subject).to receive(:get_docs).with(request_resp_1)
+        .and_return([doc, doc])
+      allow(subject).to receive(:get_docs).with(request_resp_2)
+        .and_return([doc])
+    end
+
+    context 'given an IDSource with multiple IDs and batches' do
+      let(:id_fh) { StringIO.new("1,\n2,\n3,") }
+      subject { described_class.new(id_source_fh: id_fh, batchsize: 2) }
+
+      it 'enumerates the correct number of records' do
+        all_records = []
+        subject.send(:enumerate_records).each {|r| all_records << r }
+        expect(all_records).to eq [doc, doc, doc]
+      end
+
+      context 'when encountering an HTTP error' do
+        before do
+          allow(subject).to receive(:request).with(params_1)
+            .and_raise(RestClient::InternalServerError)
+        end
+
+        it 'logs the exception and moves on to the next request' do
+          all_records = []
+          expect(Rails.logger).to receive(:error)
+            .with("request failed with params #{params_1['params']}")
+          subject.send(:enumerate_records).each {|r| all_records << r }
+          # failed request had 2 records, successful one had 1
+          expect(all_records.count).to eq 1
+        end
+      end
+    end
+  end  # #enumerate_records
+
+  describe '#get_docs' do
+    let(:parsed_response) do
+      {
+        'opaResponse' => {
+          'results' => {
+            'result' => [doc, doc]
+          }
+        }
+      }
+    end
+
+    it 'returns the docs from a parsed response' do
+      expect(subject.send(:get_docs, parsed_response)).to eq [doc, doc]
+    end
+  end
+end

--- a/spec/lib/heidrun/id_source_spec.rb
+++ b/spec/lib/heidrun/id_source_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Heidrun::IDSource do
+
+  subject { described_class.new(StringIO.new("1,\n2,\n3,"), 2) }
+
+  describe '#batches' do
+    it 'returns ids in correctly-sized batches' do
+      all_batches = []
+      subject.batches.each {|b| all_batches << b }
+      expect(all_batches).to eq [["1", "2"], ["3"]]
+    end
+  end
+
+  describe '#count' do
+    it 'returns the correct count' do
+      expect(subject.count).to eq 3
+    end
+  end
+end


### PR DESCRIPTION
This adds a harvester for NARA, plus a class, IDSource, that's used as a temporary measure to drive the harvest by providing record identifiers from a file, in lieu of our being able to page completely through NARA's result set.
