### PR TITLE
Bump up sass-rails version to fix deployment error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.1.10'
 gem 'krikri', '0.6.0'
 
 gem 'sqlite3'
-gem 'sass-rails', '~> 4.0.3'
+gem 'sass-rails', '~> 5.0.0'
 
 # Gems used only for assets; not required by rails
 # in production environments.


### PR DESCRIPTION
We were getting an error from `rake assets:precompile` during deployments, as follows:

    undefined method `type' for .focus:Sass::Selector::Class (NoMethodError)

This appears to be related to https://github.com/sass/sass/issues/1656

The quick fix for `heidrun` is to bump sass-rails up to version 5.x.