### PR TITLE
Add enrichment for removing "placeholder" values

### DIFF
--- a/app/enrichments/remove_placeholder.rb
+++ b/app/enrichments/remove_placeholder.rb
@@ -1,0 +1,73 @@
+##
+# Removes placeholder values from a field. Applies to both straight string 
+# values and Resources with a matching `providedLabel`. Matches are case
+# insensitive by default.
+#
+# @example 
+#   rp = RemovePlaceholder.new('moomin')
+#   rp.enrich_value('moomin') # => nil
+#   rp.enrich_value('MooMin') # => nil
+#   rp.enrich_value('Little My') # => 'Little My'
+#
+# @example case sensitive
+#   rp = RemovePlaceholder.new('moomin', false)
+#   rp.enrich_value('moomin') # => nil
+#   rp.enrich_value('MooMin') # => 'MooMin'
+#   rp.enrich_value('Little My') # => 'Little My'
+#
+# @example with Resource value
+#   rp = RemovePlaceholder.new('moomin')
+#   concept = DPLA::MAP::Concept.new
+#   concept.providedLabel = 'moomin'
+#   rp.enrich_value(concept) # => nil
+#
+# This method also supports regexp matchers. Write your regexp's with care!
+# Expressions combine with case sensitivity on input strings.
+#
+# @example with regexp
+#   rp = RemovePlaceholder.new(/^\d*$/)
+#   concept = DPLA::MAP::Concept.new
+#   concept.providedLabel = '123'
+#   rp.enrich_value(concept) # => nil
+#
+# @see Audumbla::FieldEnrichment
+class RemovePlaceholder
+  include Audumbla::FieldEnrichment
+
+  ## 
+  # @param [String] placeholder  a string value to regard as a placeholder
+  # @param [Boolean] downcase  whether to downcase the placeholder and string
+  #   value when checking matching
+  def initialize(placeholder = 'xyz', downcase = true)
+    @placeholder = placeholder
+    @downcase = downcase
+  end
+
+  ##
+  # Removes values matching the given placeholder value, either directly or
+  # with the `#providedLabel` field.
+  #
+  # @see Audumbla::FieldEnrichment#enrich_value
+  def enrich_value(value)
+    if value.is_a? String
+      return nil if is_placeholder? value
+    elsif value.respond_to?(:providedLabel)
+      return nil if value.providedLabel.find { |l| !is_placeholder?(l) }.nil?
+    end
+    return value
+  end
+
+  private
+  
+  ##
+  # @param [String] string
+  # @return [Boolean] true if the parameter matches the placeholder, 
+  #   false otherwise
+  def is_placeholder?(string)
+    match_str = @downcase ? string.downcase : string
+    return @placeholder =~ match_str if @placeholder.is_a? Regexp
+    match_str == (@downcase ? @placeholder.downcase : @placeholder)
+  end
+end
+  
+  

--- a/spec/enrichments/remove_placeholder_spec.rb
+++ b/spec/enrichments/remove_placeholder_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe RemovePlaceholder do
+  it_behaves_like 'a field enrichment'
+
+  context 'with string value' do
+    it 'removes matching values' do
+      str = 'xYz'
+      expect(subject.enrich_value(str)).to be_nil
+    end
+
+    it 'leaves other values alone' do
+      str = 'moomin'
+      expect(subject.enrich_value(str)).to eq str
+    end
+
+    context 'with downcase false' do
+      subject { described_class.new('AbC', false) }
+
+      it 'removes matching values' do
+        str = 'AbC'
+        expect(subject.enrich_value(str)).to be_nil
+      end
+
+      it 'leaves other values alone' do
+        str = 'abc'
+        expect(subject.enrich_value(str)).to eq str
+      end
+    end
+
+    context 'with regexp' do
+      subject { described_class.new(/^\d*$/) }
+      
+      it 'removes matching values' do
+        str = '123'
+        expect(subject.enrich_value(str)).to be_nil
+      end
+
+      it 'leaves other values alone' do
+        str = '12c'
+        expect(subject.enrich_value(str)).to eq str
+      end
+    end
+  end
+
+  context 'with Resource value' do
+    let(:value) { double('Resource') }
+
+    before do
+      allow(value).to receive(:respond_to?)
+                       .with(:providedLabel).and_return(true)
+    end
+
+    it 'removes matching values' do
+      allow(value).to receive(:providedLabel).and_return(['xYz'])
+      expect(subject.enrich_value(value)).to be_nil
+    end
+
+    it 'leaves other values alone' do
+      allow(value).to receive(:providedLabel).and_return(['moomin'])
+      expect(subject.enrich_value(value)).to eq value
+    end
+
+    it 'leaves multiple values alone' do
+      allow(value).to receive(:providedLabel).and_return(['moomin', 'xYz'])
+      expect(subject.enrich_value(value)).to eq value
+    end
+
+    context 'with regexp' do
+      subject { described_class.new(/^\d*$/) }
+
+      it 'removes matching values' do
+        allow(value).to receive(:providedLabel).and_return(['123'])
+        expect(subject.enrich_value(value)).to be_nil
+      end
+
+      it 'leaves other values alone' do
+        allow(value).to receive(:providedLabel).and_return(['12c'])
+        expect(subject.enrich_value(value)).to eq value
+      end
+
+      it 'leaves multiple values alone' do
+        allow(value).to receive(:providedLabel).and_return(['123', '12c'])
+        expect(subject.enrich_value(value)).to eq value
+      end
+    end
+
+    context 'with downcase false' do
+      subject { described_class.new('AbC', false) }
+
+      it 'removes matching values' do
+        allow(value).to receive(:providedLabel).and_return(['AbC'])
+        expect(subject.enrich_value(value)).to be_nil
+      end
+
+      it 'leaves other values alone' do
+        allow(value).to receive(:providedLabel).and_return(['abc'])
+        expect(subject.enrich_value(value)).to eq value
+      end
+
+      it 'leaves multiple values alone' do
+        allow(value).to receive(:providedLabel).and_return(['AbC', 'abc'])
+        expect(subject.enrich_value(value)).to eq value
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'rspec/rails'
 
 require 'factory_girl_rails'
 require 'dpla/map/factories'
+require 'audumbla/spec/enrichment'
 require 'rdf/marmotta'
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
Adds an enrichment for removing values that the provider includes as a non-value "placeholder".

As an example: University of Washington includes some subjects that read simply "xyz". This is the default match value for the enrichment.