### PR TITLE
Introduce the HathiHarvester

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'pry-doc'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'webmock', :require => false
 end
 
 gem "factory_girl_rails", "~> 4.4.0", group: :development

--- a/app/harvesters/hathi_harvester.rb
+++ b/app/harvesters/hathi_harvester.rb
@@ -1,0 +1,104 @@
+require 'net/http'
+require 'rubygems/package'
+require 'zlib'
+
+##
+# A harvester for Hathi Trust MARC XML dump files.
+#
+# Supports either harvesting a previously downloaded dump file, or downloading
+# the latest available dump file and harvesting that.
+class HathiHarvester < Krikri::Harvesters::MarcXMLHarvester
+  ##
+  # @see Krikri::Harvesters::MarcXMLHarvester#each_collection
+  def each_collection
+    tarball_source do |tar_file|
+      each_tar_entry(tar_file) do |entry|
+        yield entry
+      end
+    end
+  end
+
+  private
+
+  ##
+  # @yield [IO] Give an IO stream containing an archive of MARC XML collection
+  #   files in TAR format.
+  def tarball_source(&block)
+    if File.exist?(uri)
+      File.open(uri, &block)
+    elsif URI.parse(uri).instance_of?(URI::Generic)
+      fail IOError, "'#{uri}' doesn't exist as a file and isn't a valid URL."
+    else
+      download_url(latest_tarball_url, &block)
+    end
+  end
+
+  ##
+  # @return [URI] Determine the URL of the most recent Hathi data dump.
+  def latest_tarball_url
+    html = Net::HTTP.get(URI(uri))
+    parsed_html = Nokogiri::HTML(html)
+
+    file_names = parsed_html.xpath('//a[contains(@href, "dpla_full")]')
+                 .map { |a| a.get_attribute('href') }
+    latest_file = file_names.sort.reverse.first
+
+    URI.join(uri, latest_file)
+  end
+
+  ##
+  # Download the contents of a URL to a temporary file.
+  #
+  # @yield [File] If a block is given, the temporary file will be provided and
+  #   removed when the block returns.
+  # @return [File] If no block is given, return the temporary file.  The caller
+  #   must call #unlink once finished with the file.
+  def download_url(url)
+    Net::HTTP.start(url.host, url.port) do |http|
+      request = Net::HTTP::Get.new(url.request_uri)
+
+      # Make sure the HTTP client doesn't handle the gzip compression on our
+      # behalf.  We'll take care of it when we're streaming the temp file.
+      #
+      request['Accept-Encoding'] = 'identity'
+
+      # Force ASCII decoding to ensure we're working with plain bytes.  Without
+      # this, we throw exceptions on bytes with the high bit set:
+      #
+      # Encoding::UndefinedConversionError: "\x8B" from ASCII-8BIT to UTF-8 file
+      #
+      file = Tempfile.new('hathi', Dir.tmpdir, encoding: 'ASCII-8BIT')
+
+      http.request(request) do |resp|
+        resp.read_body do |seg|
+          file.write(seg)
+        end
+      end
+
+      file.close
+
+      if block_given?
+        begin
+          yield file
+        ensure
+          file.unlink
+        end
+      else
+        file
+      end
+    end
+  end
+
+  ##
+  # @yield [IO] Provide the stream of each XML entry in a Tar file to the
+  #   provided block.
+  def each_tar_entry(file)
+    Gem::Package::TarReader.new(Zlib::GzipReader.open(file)) do |tar|
+      tar.each do |entry|
+        if entry.file? && entry.full_name.downcase.end_with?('.xml')
+          yield entry
+        end
+      end
+    end
+  end
+end

--- a/spec/harvesters/hathi_harvester_spec.rb
+++ b/spec/harvesters/hathi_harvester_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+##
+# Helper methods for building our test data
+module HathiTestHelpers
+  def tar_stream(*records)
+    result = StringIO.new
+
+    Gem::Package::TarWriter.new(result) do |tar|
+      records.each_with_index do |record, i|
+        tar.add_file("file_#{i}.xml", 0755) do |io|
+          io.write(record)
+        end
+      end
+    end
+
+    result.string
+  end
+
+  def gzip(s)
+    result = StringIO.new('w')
+
+    gzip = Zlib::GzipWriter.new(result)
+    gzip.write(s)
+    gzip.close
+
+    result.string
+  end
+end
+
+describe HathiHarvester, :webmock => true do
+  include HathiTestHelpers
+
+  let(:base_url) { 'http://example.com' }
+  let(:target_file) { 'dpla_full_20151101.tar.gz' }
+
+  let(:index_page) do
+    <<-EOS
+    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+    <html>
+     <head><title>Index of /</title></head>
+     <body>
+      <h1>Index of /</h1>
+      <a href="dpla_full_20151025.tar.gz">dpla_full_20151025.t..&gt;</a>
+      <a href="dpla_full_20151101.tar.gz">dpla_full_20151101.t..&gt;</a>
+      <a href="dpla_full_20140901.tar.gz">dpla_full_20140901.t..&gt;</a>
+     </body>
+    </html>
+    EOS
+  end
+
+  let(:marc_record) do
+    <<-EOS
+    <collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+                xmlns="http://www.loc.gov/MARC21/slim">
+      <record>
+        <controlfield tag="001">12345</controlfield>
+      </record>
+    </collection>
+    EOS
+  end
+
+  let(:sample_records) { gzip(tar_stream(marc_record)) }
+
+  describe '#each_collection' do
+    let(:harvester) { HathiHarvester.new(uri: base_url) }
+
+    describe 'index page lookup' do
+      before(:each) do
+        stub_request(:get, base_url)
+          .to_return(status: 200, body: index_page, headers: {})
+
+        stub_request(:get, "#{base_url}/#{target_file}")
+          .to_return(status: 200, body: sample_records, headers: {})
+
+        @fetched_records = []
+        harvester.each_collection do |record|
+          @fetched_records << record.read
+        end
+      end
+
+      it 'fetches the most recent tarball automatically' do
+        expect(WebMock).to have_requested(:get, base_url)
+        expect(WebMock).to have_requested(:get, "#{base_url}/#{target_file}")
+      end
+
+      it 'gets back the records we expect' do
+        expect(@fetched_records.first).to match(/controlfield.*1234/)
+      end
+
+      it 'disables automatic GZIP decompression' do
+        expect(WebMock).to have_requested(:get, "#{base_url}/#{target_file}")
+                            .with(headers: { 'Accept-Encoding' => 'identity' })
+      end
+    end
+
+    it 'accepts a file path' do
+      Tempfile.create('hathi_test') do |records|
+        records.write(sample_records)
+        records.flush
+
+        HathiHarvester.new(uri: records.path).each_collection do |record|
+          expect(record.read).to match(/controlfield.*1234/)
+        end
+      end
+    end
+
+    it 'fails on a non-existent file path' do
+      expect {
+        HathiHarvester.new(uri: '/very/unlikely/to/exist')
+          .each_collection { |record| }
+      }.to raise_error(IOError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ require 'factory_girl_rails'
 require 'dpla/map/factories'
 require 'audumbla/spec/enrichment'
 require 'rdf/marmotta'
+require 'webmock/rspec'
+
+WebMock.allow_net_connect!
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
@@ -36,5 +39,13 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     clear_repository
+  end
+
+  config.before(:each) do |example|
+    if example.metadata[:webmock]
+      WebMock.disable_net_connect!
+    else
+      WebMock.allow_net_connect!
+    end
   end
 end


### PR DESCRIPTION
The `HathiHarvester` relies on the `MarcXMLHarvester` defined in the Krikri PR https://github.com/dpla/KriKri/pull/204.

The harvester requires either a `:url` or `:dump_file` parameter.

The `:url` is a string URL of the tarball listing.  The harvester will parse this page, identify the latest tarball, download the latest to a temporary file and then perform the harvest on the MARC XML documents in that file.

Alternatively, you can target an already downloaded tarball with the `:dump_file` parameter, where `:dump_file` is the path to file.

For testing, we also support a `:max_records` parameter to limit the number records to be ingested.