### PR TITLE
Modify LDP regexp to work under CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
 
       # `OriginalRecord.build` will look for an existing record.  Just assume
       # there isn't one by default.
-      stub_request(:head, %r{http://ldp.local.dp.la/ldp/original_record/[0-9a-f]+\z})
+      stub_request(:head, %r{/ldp/original_record/[0-9a-f]+\z})
         .to_return(status: 404)
     else
       WebMock.allow_net_connect!


### PR DESCRIPTION
The hostname ends up being slightly different when running the
continuous integration: localhost vs local.dp.la.