### PR TITLE
Fix install_ruby_tools.sh issues

### DIFF
--- a/provisioning/files/install_ruby_tools.sh
+++ b/provisioning/files/install_ruby_tools.sh
@@ -34,3 +34,6 @@ else
 fi
 rbenv rehash
 
+if (! `grep -q DISABLE_SPRING ~/.bashrc`); then
+    echo "export DISABLE_SPRING=1" >> ~/.bashrc
+fi

--- a/provisioning/files/install_ruby_tools.sh
+++ b/provisioning/files/install_ruby_tools.sh
@@ -17,13 +17,13 @@ export PATH=$HOME/.rbenv/bin:$PATH
 eval "$(rbenv init -)"
 
 if [ -d $HOME/.rbenv/versions/$USE_VERSION ]; then
-    export RBENV_VERSION=$USE_VERSION
+    rbenv global $USE_VERSION
 else
     rbenv install $USE_VERSION
     if [ $? -ne 0 ]; then
         exit 1
     fi
-    export RBENV_VERSION=$USE_VERSION
+    rbenv global $USE_VERSION
 fi
 
 bundler=`gem list bundler | grep bundler`


### PR DESCRIPTION
Disable Spring for the `vagrant` user so it doesn't interfere with the use of the Rails console. See https://github.com/dpla/automation/commit/fa0e9b3e19da5b50ff5fef0a891600bfa41213dd

Set `rbenv global` so it's always correct whenever you do `vagrant ssh`.
