### PR TITLE
Parameterize log_level configuration setting

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,4 +34,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.log_level = Settings.log_level.to_sym
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,8 +41,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Set to :debug to see everything in the log.
-  config.log_level = :info
+  config.log_level = Settings.log_level.to_sym
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,4 +36,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.log_level = Settings.log_level.to_sym
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,3 +6,5 @@
 redis:
     host: localhost
     port: 6379
+
+log_level: debug

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Heidrun::Application do
+  let(:config) { described_class.config }
+  before do
+    allow(Settings).to receive(:log_level).and_return(:debug)
+  end
+
+  it 'configures log level' do
+    expect(config.log_level).to eq :debug
+  end
+end


### PR DESCRIPTION
Parameterize the `log_level` setting, so that we're not tied to a particular level of logging in a given deployment environment. This should assist with troubleshooting.
