### PR TITLE
Upgrade Rake & tighten up rake dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.1.11'
+gem 'rake',  '~> 11.0.0'
 
 gem 'krikri', '~> 0.10', '>=0.10.0'
 
@@ -27,7 +28,7 @@ group :test do
 end
 
 group :development, :test do
-  gem 'rspec-core', '~>3.1'
+  gem 'rspec-core',  '~>3.4.4'
   gem 'rspec-rails', '~>3.1'
   gem 'pry'
   gem 'pry-doc'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,11 +39,13 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     clear_repository
+    WebMock.allow_net_connect!
   end
 
   config.before(:each) do |example|
     if example.metadata[:webmock]
-      WebMock.disable_net_connect!
+      WebMock.disable_net_connect!(:allow_localhost => true, 
+                                   allow: 'codeclimate.com')
     else
       WebMock.allow_net_connect!
     end


### PR DESCRIPTION
Rake 11.0.0 was recently released. This upgrades us explicitly and locks
down the dependency to the minor version for better future safety.

We're doing this on Heidrun rather than Krikri to avoid locking other
potential Krikri (engine) users to a specific Rake version. This is more
maintenance overhead on Krikri in the long run, but it seems like the
only viable choice to avoid dependency conflicts.