### PR TITLE
Use krikri-spec shared examples/matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :test do
 end
 
 group :development, :test do
+  gem 'krikri-spec', github: 'dpla/krikri-spec', branch: 'develop'
   gem 'rspec-core',  '~>3.4.4'
   gem 'rspec-rails', '~>3.1'
   gem 'pry'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 
+require 'krikri/spec'
+
 require 'factory_girl_rails'
 require 'dpla/map/factories'
 require 'audumbla/spec/enrichment'
@@ -24,6 +26,7 @@ RSpec.configure do |config|
   config.mock_with :rspec
 
   config.include FactoryGirl::Syntax::Methods
+  config.include Krikri::Spec::Matchers
 
   config.use_transactional_fixtures = false
   config.infer_base_class_for_anonymous_controllers = false


### PR DESCRIPTION
Adds the new `krikri-spec` gem (pending release/rebase) to introduces the
shared examples and matchers.

After this change, some development workflows:

  - `krikri-spec` should be kept up-to-date. to this end, it is pinned to the
  develop branch on GitHub in the Gemfile.
  - It will occasionally be useful to use local copies of `krikri-spec`,
  especially when working on tests as described above. To do this, it's
  recommended that you use Bundler's path: option. See:
  https://github.com/dpla/krikri-spec#development