### PR TITLE
pin gems from krikri to tiny versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,15 @@ gem 'jettywrapper', '~> 2.0.3', group: :development
 gem 'devise', '3.4.1'
 gem 'pg', '0.18.2'
 gem 'unicorn', '4.8.3'
+
+# Gems from krikri (@see KriKri/krikri.gemspec)
+# In krikri, these gems are pinned to major or minor verions.
+# Here, they are pinned to tiny versions so we can manage them more
+# intentionally.
+
+gem 'audumbla', '~> 0.2.1'
+gem 'rest-client', '~> 2.0.0'
+gem 'text', '~> 1.3'
+gem 'jsonpath', '~> 0.5.8'
+gem 'resque', '~> 1.26.0'
+gem 'timecop', '~> 0.8.1'


### PR DESCRIPTION
This adds gems to the gemfile and pins them to tiny versions.  In the Krikri app, these gems are defined and pinned to major or minor versions.  The loose definition of gems in Krikri gives intentional flexibility to Krikri adopters.  However, for the sake of managing dependencies in Heidrun, it is advantageous to re-define these same gems within the Heidrun app, pinned to tiny versions.  The trade-off is that we will need to coordinate upgrades of these gems between Krikri and Heidrun in the future.

This addresses [ticket #8538](https://issues.dp.la/issues/8538).
